### PR TITLE
feat: introduce AuthGuard

### DIFF
--- a/src/app/app-routing.module.ts
+++ b/src/app/app-routing.module.ts
@@ -4,12 +4,17 @@ import { WelcomeComponent } from './welcome/welcome.component'
 import { SignupComponent } from './auth/signup/signup.component'
 import { LoginComponent } from './auth/login/login.component'
 import { TrainingComponent } from './training/training.component'
+import { AuthGuard } from './auth/auth.guard'
 
 const routes: Routes = [
   { path: '', component: WelcomeComponent },
   { path: 'signup', component: SignupComponent },
   { path: 'login', component: LoginComponent },
-  { path: 'training', component: TrainingComponent }
+  {
+    path: 'training',
+    component: TrainingComponent,
+    canActivate: [ AuthGuard ]
+  }
 ]
 
 @NgModule({
@@ -18,6 +23,9 @@ const routes: Routes = [
   ],
   exports: [
     RouterModule
+  ],
+  providers: [
+    AuthGuard
   ]
 })
 export class AppRoutingModule {}

--- a/src/app/auth/auth.guard.ts
+++ b/src/app/auth/auth.guard.ts
@@ -1,0 +1,16 @@
+import { ActivatedRouteSnapshot, CanActivate, Router, RouterStateSnapshot } from '@angular/router'
+import { Injectable } from '@angular/core'
+import { AuthService } from './auth.service'
+
+@Injectable()
+export class AuthGuard implements CanActivate {
+  constructor(private auth: AuthService, private router: Router) {}
+
+  canActivate(route: ActivatedRouteSnapshot, state: RouterStateSnapshot) {
+    if (this.auth.isAuthenticated()) {
+      return true
+    } else {
+      this.router.navigate(['/login'])
+    }
+  }
+}


### PR DESCRIPTION
Right now, it's only used to block logged-out users from accessing the /training route, redirecting to /login.